### PR TITLE
BMM350: Change comp_m_z to be calculated from m_z instead of m_y

### DIFF
--- a/src/umrx_app_v3/sensors/bmm350.py
+++ b/src/umrx_app_v3/sensors/bmm350.py
@@ -497,7 +497,7 @@ class BMM350:
         comp_m_y = m_y * (1 + self.sens_y) + self.offset_y + self.tco_y * (compensated_temperature - self.dut_t0)
         comp_m_y /= 1 + self.tcs_y * (compensated_temperature - self.dut_t0)
 
-        comp_m_z = m_y * (1 + self.sens_z) + self.offset_z + self.tco_z * (compensated_temperature - self.dut_t0)
+        comp_m_z = m_z * (1 + self.sens_z) + self.offset_z + self.tco_z * (compensated_temperature - self.dut_t0)
         comp_m_z /= 1 + self.tcs_z * (compensated_temperature - self.dut_t0)
 
         cross_m_x = (comp_m_x - self.cross_x_y * comp_m_y) / (1 - self.cross_y_x * self.cross_x_y)


### PR DESCRIPTION
The readings I was seeing using this library didn't match the output when using Bosch's Development Desktop app. After making this change, z channel readings are what I expect.